### PR TITLE
feat: notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+CloudFront: https://d3iw5to04tnclb.cloudfront.net/

--- a/packages/import-service/import-file-parser/copy-object.ts
+++ b/packages/import-service/import-file-parser/copy-object.ts
@@ -1,5 +1,5 @@
 import { BUCKET } from '../bucket';
-import S3 from 'aws-sdk/clients/S3';
+import S3 from 'aws-sdk/clients/s3';
 
 export const copyObject = async (
   filename: string,

--- a/packages/import-service/import-file-parser/delete-object.ts
+++ b/packages/import-service/import-file-parser/delete-object.ts
@@ -1,4 +1,4 @@
-import S3 from 'aws-sdk/clients/S3';
+import S3 from 'aws-sdk/clients/s3';
 import { BUCKET } from '../bucket';
 
 export const deleteObject = async (filename: string) => {

--- a/packages/import-service/import-file-parser/send-data.ts
+++ b/packages/import-service/import-file-parser/send-data.ts
@@ -1,3 +1,16 @@
+import SQS from 'aws-sdk/clients/sqs';
+
 export const sendData = async (data) => {
   console.log(data);
+  try {
+    const sqs = new SQS();
+    await sqs
+      .sendMessage({
+        MessageBody: JSON.stringify(data),
+        QueueUrl: process.env.SQS_QUEUE_URL,
+      })
+      .promise();
+  } catch (e) {
+    console.error(e);
+  }
 };

--- a/packages/import-service/import-products-file/import-products-file.ts
+++ b/packages/import-service/import-products-file/import-products-file.ts
@@ -1,12 +1,9 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
-import S3 from 'aws-sdk/clients/s3';
+import { S3 } from 'aws-sdk';
 import { BUCKET } from '../bucket';
 import { cors } from '../cors';
 
-export const importProductsFile: APIGatewayProxyHandler = async (
-  event,
-  _context,
-) => {
+export const importProductsFile: APIGatewayProxyHandler = async (event) => {
   console.log('Request: ', JSON.stringify(event, null, 2));
   const s3 = new S3({ region: 'eu-central-1' });
   try {

--- a/packages/import-service/serverless.ts
+++ b/packages/import-service/serverless.ts
@@ -26,6 +26,7 @@ const serverlessConfiguration: Serverless = {
     },
     environment: {
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      SQS_QUEUE_URL: '${cf:product-service-${self:provider.stage}.SqsQueueUrl}',
     },
     iamRoleStatements: [
       {
@@ -37,6 +38,11 @@ const serverlessConfiguration: Serverless = {
         Effect: 'Allow',
         Action: ['s3:*'],
         Resource: [`arn:aws:s3:::${BUCKET}/*`],
+      },
+      {
+        Effect: 'Allow',
+        Action: ['sqs:*'],
+        Resource: ['${cf:product-service-${self:provider.stage}.SqsQueueArn}'],
       },
     ],
   },

--- a/packages/product-service/catalogBatchProcess/catalogBatchProcess.test.ts
+++ b/packages/product-service/catalogBatchProcess/catalogBatchProcess.test.ts
@@ -1,0 +1,71 @@
+import { SQSEvent } from 'aws-lambda';
+import * as AwsMock from 'aws-sdk-mock';
+import AWS from 'aws-sdk';
+
+import { saveProduct } from '../db/saveProduct';
+import { Product } from '../models/product';
+import { catalogBatchProcess } from './catalogBatchProcess';
+
+jest.mock('../db/saveProduct');
+
+describe('catalogBatchProcess', () => {
+  let product: Product;
+  let snsPublishMock: jest.Mock;
+
+  beforeEach(() => {
+    process.env.SNS_ARN = 'arn';
+    product = {
+      id: '1',
+      description: 'desc',
+      title: 'title',
+      count: 10,
+      price: 100,
+    };
+    (saveProduct as jest.Mock).mockResolvedValue(product);
+    snsPublishMock = jest.fn();
+    AwsMock.setSDKInstance(AWS);
+    AwsMock.mock('SNS', 'publish', (params: any, callback: any) => {
+      snsPublishMock(params);
+      callback(null, 'success');
+    });
+  });
+
+  afterEach(() => {
+    AwsMock.restore('SNS');
+  });
+
+  it('should save product to db', async () => {
+    await catalogBatchProcess(
+      ({
+        Records: [
+          {
+            body: JSON.stringify(product),
+          },
+        ],
+      } as unknown) as SQSEvent,
+      {} as any,
+      jest.fn(),
+    );
+    expect(saveProduct).toHaveBeenCalledWith(product);
+  });
+
+  it('should publish parsed data to email', async () => {
+    await catalogBatchProcess(
+      ({
+        Records: [
+          {
+            body: JSON.stringify(product),
+          },
+        ],
+      } as unknown) as SQSEvent,
+      {} as any,
+      jest.fn(),
+    );
+
+    expect(snsPublishMock).toHaveBeenCalledWith({
+      Subject: 'New product was uploaded',
+      Message: JSON.stringify(product),
+      TopicArn: process.env.SNS_ARN,
+    });
+  });
+});

--- a/packages/product-service/catalogBatchProcess/catalogBatchProcess.ts
+++ b/packages/product-service/catalogBatchProcess/catalogBatchProcess.ts
@@ -1,0 +1,50 @@
+import { SQSHandler } from 'aws-lambda';
+import { saveProduct } from '../db/saveProduct';
+import AWS from 'aws-sdk';
+
+export const catalogBatchProcess: SQSHandler = async (event) => {
+  console.log(JSON.stringify(event, null, 2));
+
+  const sns = new AWS.SNS();
+  await Promise.all(
+    event.Records.map(async (record) => {
+      try {
+        const product = JSON.parse(record.body);
+        const { id, description, title, price, count } = await saveProduct(
+          product,
+        );
+        await sns
+          .publish({
+            Subject: 'Product-service',
+            Message: 'New product was successfully uploaded from the ui',
+            MessageAttributes: {
+              id: {
+                DataType: 'String',
+                StringValue: id,
+              },
+              description: {
+                DataType: 'String',
+                StringValue: description,
+              },
+              title: {
+                DataType: 'String',
+                StringValue: title,
+              },
+              price: {
+                DataType: 'Number',
+                StringValue: JSON.stringify(price),
+              },
+              count: {
+                DataType: 'Number',
+                StringValue: JSON.stringify(count),
+              },
+            },
+            TopicArn: process.env.SNS_ARN,
+          })
+          .promise();
+      } catch (e) {
+        console.error(e);
+      }
+    }),
+  );
+};

--- a/packages/product-service/catalogBatchProcess/index.ts
+++ b/packages/product-service/catalogBatchProcess/index.ts
@@ -1,0 +1,1 @@
+export * from './catalogBatchProcess';

--- a/packages/product-service/handlers.ts
+++ b/packages/product-service/handlers.ts
@@ -1,3 +1,4 @@
 export * from './getProductById';
 export * from './getProductsList';
 export * from './addProduct';
+export * from './catalogBatchProcess';

--- a/packages/product-service/package.json
+++ b/packages/product-service/package.json
@@ -4,10 +4,11 @@
   "description": "Serverless webpack example using Typescript",
   "main": "handler.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --coverage",
     "deploy": "sls deploy"
   },
   "dependencies": {
+    "aws-sdk": "^2.797.0",
     "pg": "^8.4.2",
     "source-map-support": "^0.5.10",
     "yup": "^0.30.0"

--- a/packages/product-service/serverless.ts
+++ b/packages/product-service/serverless.ts
@@ -19,7 +19,7 @@ const serverlessConfiguration: Serverless = {
     'serverless-webpack',
     'serverless-plugin-monorepo',
     'serverless-dotenv-plugin',
-    'serverless-event-body-option'
+    'serverless-event-body-option',
   ],
   provider: {
     name: 'aws',
@@ -30,7 +30,25 @@ const serverlessConfiguration: Serverless = {
     },
     environment: {
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      SQS_URL: {
+        Ref: 'SqsQueue',
+      },
+      SNS_ARN: {
+        Ref: 'SnsTopic',
+      },
     },
+    iamRoleStatements: [
+      {
+        Effect: 'Allow',
+        Action: ['sqs:*'],
+        Resource: [{ 'Fn::GetAtt': ['SqsQueue', 'Arn'] }],
+      },
+      {
+        Effect: 'Allow',
+        Action: ['sns:*'],
+        Resource: [{ Ref: 'SnsTopic' }],
+      },
+    ],
   },
   functions: {
     getProductsList: {
@@ -75,6 +93,70 @@ const serverlessConfiguration: Serverless = {
           },
         },
       ],
+    },
+    catalogBatchProcess: {
+      handler: 'handlers.catalogBatchProcess',
+      events: [
+        {
+          sqs: {
+            batchSize: 5,
+            arn: {
+              'Fn::GetAtt': ['SqsQueue', 'Arn'],
+            },
+          },
+        },
+      ],
+    },
+  },
+  resources: {
+    Resources: {
+      SqsQueue: {
+        Type: 'AWS::SQS::Queue',
+        Properties: {
+          QueueName: 'catalogItemsQueue',
+        },
+      },
+      SnsTopic: {
+        Type: 'AWS::SNS::Topic',
+        Properties: {
+          TopicName: 'createProductTopic',
+        },
+      },
+      SnsSubscription: {
+        Type: 'AWS::SNS::Subscription',
+        Properties: {
+          Endpoint: 'denys.kovalishyn@gmail.com',
+          Protocol: 'email',
+          TopicArn: {
+            Ref: 'SnsTopic',
+          },
+        },
+      },
+      SnsHighPriceSubscription: {
+        Type: 'AWS::SNS::Subscription',
+        Properties: {
+          Endpoint: 'dkovalishyn@gmail.com',
+          Protocol: 'email',
+          TopicArn: {
+            Ref: 'SnsTopic',
+          },
+          FilterPolicy: {
+            price: [{ numeric: ['>', 1000] }],
+          },
+        },
+      },
+    },
+    Outputs: {
+      SqsQueueUrl: {
+        Value: {
+          Ref: 'SqsQueue',
+        },
+      },
+      SqsQueueArn: {
+        Value: {
+          'Fn::GetAtt': ['SqsQueue', 'Arn'],
+        },
+      },
     },
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,6 +2992,21 @@ aws-sdk@*, aws-sdk@^2.637.0, aws-sdk@^2.790.0:
     uuid "3.3.2"
     xml2js "0.4.19"
 
+aws-sdk@^2.797.0:
+  version "2.797.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.797.0.tgz#e9510a582606a580e7bbb686f01da28476599a2d"
+  integrity sha512-fFc/2Xr7NkSXlZ9+2rCOFovA9NO1OnIyEaJFVwMM9gaqzucwRAfNNT0Pa1Kua5dhWrcf/mX0Z4mCDnTBf0/5mA==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"


### PR DESCRIPTION
CloudFront: https://d3iw5to04tnclb.cloudfront.net/

What was done:
1 - File serverless.ts contains configuration for catalogBatchProcess function
2 - File serverless.ts contains policies to allow lambda catalogBatchProcess function to interact with SNS and SQS
3 - File serverless.ts contains configuration for SQS catalogItemsQueue
4 - File serverless.ts contains configuration for SNS Topic createProductTopic and email subscription

Additional: 
+1 - catalogBatchProcess lambda is covered by unit tests
+1 - set a Filter Policy for SNS createProductTopic in serverless.yml (Create an additional email subscription and distribute messages to different emails depending on the filter for any product attribute)
My filter policy send all information to one email and only high-price products to secondary email.