### PR TITLE
feat: authorization

### DIFF
--- a/packages/authorization-service/.gitignore
+++ b/packages/authorization-service/.gitignore
@@ -1,0 +1,11 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless
+
+# Webpack directories
+.webpack
+
+.env

--- a/packages/authorization-service/.prettierrc
+++ b/packages/authorization-service/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/authorization-service/handler.ts
+++ b/packages/authorization-service/handler.ts
@@ -1,0 +1,55 @@
+import {
+  APIGatewayAuthorizerHandler,
+  APIGatewayAuthorizerResult,
+} from 'aws-lambda';
+import 'source-map-support/register';
+
+export const basicAuthorizer: APIGatewayAuthorizerHandler = (
+  event,
+  _context,
+  cb,
+) => {
+  console.log('Event: ', JSON.stringify(event, null, 2));
+
+  if (event.type !== 'TOKEN') {
+    return cb('Unauthorized');
+  }
+
+  try {
+    const encodedCreds = event.authorizationToken.split(' ')[1];
+    const [username, password] = Buffer.from(encodedCreds, 'base64')
+      .toString('utf-8')
+      .split(':');
+
+    const userPassword = process.env[username];
+
+    const effect =
+      !userPassword || userPassword !== password ? 'Deny' : 'Allow';
+    const policy = generatePolicy(encodedCreds, event.methodArn, effect);
+
+    return cb(null, policy);
+  } catch (e) {
+    console.error(e);
+    return cb('Unauthorized');
+  }
+};
+
+const generatePolicy = (
+  principalId: string,
+  Resource: string,
+  Effect: 'Allow' | 'Deny' = 'Allow',
+): APIGatewayAuthorizerResult => {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect,
+          Resource,
+        },
+      ],
+    },
+  };
+};

--- a/packages/authorization-service/package.json
+++ b/packages/authorization-service/package.json
@@ -1,24 +1,19 @@
 {
-  "name": "import-service",
+  "name": "authorization-service",
   "version": "1.0.0",
-  "description": "Serverless webpack example using Typescript",
+  "description": "Service for authorization users",
   "main": "handler.js",
   "scripts": {
     "deploy": "sls deploy"
   },
   "dependencies": {
-    "aws-sdk": "^2.790.0",
-    "csv-parser": "^2.3.3",
     "source-map-support": "^0.5.10"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.17",
-    "@types/aws-sdk": "^2.7.0",
     "@types/node": "^10.12.18",
     "@types/serverless": "^1.72.5",
-    "aws-sdk-mock": "^5.1.0",
     "fork-ts-checker-webpack-plugin": "^3.0.1",
-    "serverless-pseudo-parameters": "^2.5.0",
     "serverless-webpack": "^5.2.0",
     "ts-loader": "^5.3.3",
     "ts-node": "^8.10.2",

--- a/packages/authorization-service/serverless.ts
+++ b/packages/authorization-service/serverless.ts
@@ -1,0 +1,55 @@
+import type { Serverless } from 'serverless/aws';
+
+const serverlessConfiguration: Serverless = {
+  service: {
+    name: 'authorization-service',
+    // app and org for use with dashboard.serverless.com
+    // app: your-app-name,
+    // org: your-org-name,
+  },
+  frameworkVersion: '2',
+  custom: {
+    webpack: {
+      webpackConfig: './webpack.config.js',
+      includeModules: true,
+    },
+  },
+  // Add the serverless-webpack plugin
+  plugins: [
+    'serverless-webpack',
+    'serverless-plugin-monorepo',
+    'serverless-dotenv-plugin',
+  ],
+  provider: {
+    name: 'aws',
+    runtime: 'nodejs12.x',
+    region: 'eu-central-1',
+    apiGateway: {
+      minimumCompressionSize: 1024,
+    },
+    environment: {
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+    },
+  },
+  functions: {
+    basicAuthorizer: {
+      handler: 'handler.basicAuthorizer',
+    },
+  },
+  resources: {
+    Resources: {},
+    Outputs: {
+      BasicAuthArn: {
+        Description: 'Arn for basic authorizer lambda function',
+        Value: {
+          'Fn::GetAtt': ['BasicAuthorizerLambdaFunction', 'Arn'],
+        },
+        Export: {
+          Name: 'BasicAuthArn',
+        },
+      },
+    },
+  },
+};
+
+module.exports = serverlessConfiguration;

--- a/packages/authorization-service/tsconfig.json
+++ b/packages/authorization-service/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "lib": ["es2017"],
+    "removeComments": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true,
+    "target": "es2017",
+    "outDir": "lib"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": [
+    "node_modules/**/*",
+    ".serverless/**/*",
+    ".webpack/**/*",
+    "_warmup/**/*",
+    ".vscode/**/*"
+  ]
+}

--- a/packages/authorization-service/webpack.config.js
+++ b/packages/authorization-service/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require('path');
+const slsw = require('serverless-webpack');
+const nodeExternals = require('webpack-node-externals');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+module.exports = {
+  context: __dirname,
+  mode: slsw.lib.webpack.isLocal ? 'development' : 'production',
+  entry: slsw.lib.entries,
+  devtool: slsw.lib.webpack.isLocal ? 'cheap-module-eval-source-map' : 'source-map',
+  resolve: {
+    extensions: ['.mjs', '.json', '.ts'],
+    symlinks: false,
+    cacheWithContext: false,
+  },
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  target: 'node',
+  externals: [nodeExternals()],
+  module: {
+    rules: [
+      // all files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.(tsx?)$/,
+        loader: 'ts-loader',
+        exclude: [
+          [
+            path.resolve(__dirname, 'node_modules'),
+            path.resolve(__dirname, '.serverless'),
+            path.resolve(__dirname, '.webpack'),
+          ],
+        ],
+        options: {
+          transpileOnly: true,
+          experimentalWatchApi: true,
+        },
+      },
+    ],
+  },
+  plugins: [
+    // new ForkTsCheckerWebpackPlugin({
+    //   eslint: true,
+    //   eslintOptions: {
+    //     cache: true
+    //   }
+    // })
+  ],
+};

--- a/packages/client/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/packages/client/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import Typography from '@material-ui/core/Typography';
-import axios from 'axios';
+import React, { useState } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import axios from "axios";
 
 const useStyles = makeStyles((theme) => ({
   content: {
@@ -27,29 +27,30 @@ export default function CSVFileImport({ url, title }: CSVFileImportProps) {
   };
 
   const removeFile = () => {
-    setFile('');
+    setFile("");
   };
 
   const uploadFile = async (e: any) => {
-      // Get the presigned URL
-      const response = await axios({
-        method: 'GET',
-        url,
-        params: {
-          name: encodeURIComponent(file.name)
-        }
-      })
-      console.log('File to upload: ', file.name)
-      console.log('Uploading to: ', response.data)
-      const result = await fetch(response.data, {
-        method: 'PUT',
-        body: file
-      })
-      console.log('Result: ', result)
-      setFile('');
-    }
-  ;
-
+    // Get the presigned URL
+    const response = await axios({
+      method: "GET",
+      url,
+      headers: {
+        Authorization: `Basic ${localStorage.getItem("authorization_token")}`,
+      },
+      params: {
+        name: encodeURIComponent(file.name),
+      },
+    });
+    console.log("File to upload: ", file.name);
+    console.log("Uploading to: ", response.data);
+    const result = await fetch(response.data, {
+      method: "PUT",
+      body: file,
+    });
+    console.log("Result: ", result);
+    setFile("");
+  };
   return (
     <div className={classes.content}>
       <Typography variant="h6" gutterBottom>

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -1,21 +1,26 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import 'index.css';
-import App from 'components/App/App';
-import {store} from 'store/store';
-import {Provider} from 'react-redux';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "index.css";
+import App from "components/App/App";
+import { store } from "store/store";
+import { Provider } from "react-redux";
+import * as serviceWorker from "./serviceWorker";
 import CssBaseline from "@material-ui/core/CssBaseline";
-import axios from 'axios';
+import axios from "axios";
 
 axios.interceptors.response.use(
-  response => {
+  (response) => {
     return response;
   },
-  function(error) {
+  function (error) {
     if (error.response.status === 400) {
       alert(error.response.data?.data);
     }
+
+    if (error.response.status === 401 || error.response.status === 403) {
+      alert(error.response.data?.message);
+    }
+
     return Promise.reject(error.response);
   }
 );
@@ -23,11 +28,11 @@ axios.interceptors.response.use(
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
-      <CssBaseline/>
-      <App/>
+      <CssBaseline />
+      <App />
     </Provider>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/yarn.lock
+++ b/yarn.lock
@@ -11238,6 +11238,11 @@ serverless-plugin-monorepo@^0.9.0:
   dependencies:
     fs-extra "^7.0.0"
 
+serverless-pseudo-parameters@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.5.0.tgz#f30bf34db166e4b8b22144a8e65aca71b90dd1e6"
+  integrity sha512-A/O49AR8LL6jlnPSmnOTYgL1KqVgskeRla4sVDeS/r5dHFJlwOU5MgFilc7aaQP8NWAwRJANaIS9oiSE3I+VUA==
+
 "serverless-single-page-app-plugin@file:./packages/client/serverless-single-page-app-plugin":
   version "1.0.1"
 


### PR DESCRIPTION
CloudFront: https://d3iw5to04tnclb.cloudfront.net/

What was done:
1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
3 - import-service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
5 - update client application to send Authorization: Basic authorization_token header on import. Client should get authorization_token value from browser localStorage https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage authorization_token = localStorage.getItem('authorization_token')

Additional:
+1 - Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file